### PR TITLE
Fix continuous inferencing slicing with MFE and spectrogram features (for implementation version > 1)

### DIFF
--- a/classifier/ei_run_dsp.h
+++ b/classifier/ei_run_dsp.h
@@ -564,8 +564,6 @@ __attribute__((unused)) int extract_spectrogram_features(signal_t *signal, matri
 __attribute__((unused)) int extract_spectrogram_per_slice_features(signal_t *signal, matrix_t *output_matrix, void *config_ptr, const float sampling_frequency) {
     ei_dsp_config_spectrogram_t config = *((ei_dsp_config_spectrogram_t*)config_ptr);
 
-    static bool first_run = false;
-
     if (config.axes != 1) {
         EIDSP_ERR(EIDSP_MATRIX_SIZE_MISMATCH);
     }
@@ -575,11 +573,16 @@ __attribute__((unused)) int extract_spectrogram_per_slice_features(signal_t *sig
     /* Fake an extra frame_length for stack frames calculations. There, 1 frame_length is always
     subtracted and there for never used. But skip the first slice to fit the feature_matrix
     buffer */
-    if (first_run == true) {
-        signal->total_length += (size_t)(config.frame_length * (float)frequency);
-    }
+    static bool first_run = false;
 
-    first_run = true;
+    if(config.implementation_version < 2) {
+
+        if (first_run == true) {
+            signal->total_length += (size_t)(config.frame_length * (float)frequency);
+        }
+
+        first_run = true;
+    }
 
     // calculate the size of the MFE matrix
     matrix_size_t out_matrix_size =
@@ -669,8 +672,6 @@ __attribute__((unused)) int extract_mfe_features(signal_t *signal, matrix_t *out
 __attribute__((unused)) int extract_mfe_per_slice_features(signal_t *signal, matrix_t *output_matrix, void *config_ptr, const float sampling_frequency) {
     ei_dsp_config_mfe_t config = *((ei_dsp_config_mfe_t*)config_ptr);
 
-    static bool first_run = false;
-
     if (config.axes != 1) {
         EIDSP_ERR(EIDSP_MATRIX_SIZE_MISMATCH);
     }
@@ -680,11 +681,16 @@ __attribute__((unused)) int extract_mfe_per_slice_features(signal_t *signal, mat
     /* Fake an extra frame_length for stack frames calculations. There, 1 frame_length is always
     subtracted and there for never used. But skip the first slice to fit the feature_matrix
     buffer */
-    if (first_run == true) {
-        signal->total_length += (size_t)(config.frame_length * (float)frequency);
-    }
+    static bool first_run = false;
 
-    first_run = true;
+    if(config.implementation_version < 2) {
+
+        if (first_run == true) {
+            signal->total_length += (size_t)(config.frame_length * (float)frequency);
+        }
+
+        first_run = true;
+    }
 
     // calculate the size of the MFE matrix
     matrix_size_t out_matrix_size =


### PR DESCRIPTION
With the current SDK I noticed that using the MFE features (implementation version 2) would cause the SDK to request 1 extra frame/window than the total_signal_length given. I believe this is because a work-around from implementation version 1 is still being used when using MFE or spectrogram features regardless of the implementation_version; this commit fixed the issue for me.

This bug actually isn't present with the MFCC features, so I just applied the same fix that was already in the MFCC per_slice_features implementation to the MFE and spectrogram features. 